### PR TITLE
docs: fix simple typo, respectivly -> respectively

### DIFF
--- a/src/model/pggan/metrics/frechet_inception_distance.py
+++ b/src/model/pggan/metrics/frechet_inception_distance.py
@@ -29,7 +29,7 @@ distribution given by summary statistics (in pickle format).
 
 The FID is calculated by assuming that X_1 and X_2 are the activations of
 the pool_3 layer of the inception net for generated samples and real world
-samples respectivly.
+samples respectively.
 
 See --help to see further details.
 '''


### PR DESCRIPTION
There is a small typo in src/model/pggan/metrics/frechet_inception_distance.py.

Should read `respectively` rather than `respectivly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md